### PR TITLE
Remove Carthage-specific paths, remove Box and Result from copy phase

### DIFF
--- a/Pipes.xcodeproj/project.pbxproj
+++ b/Pipes.xcodeproj/project.pbxproj
@@ -17,8 +17,6 @@
 		1EA6039C1AF0259100B1E32B /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA6039B1AF0259100B1E32B /* Result.swift */; };
 		1EA603A41AF0272600B1E32B /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EA603A21AF0272600B1E32B /* Box.framework */; };
 		1EA603A51AF0272600B1E32B /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EA603A31AF0272600B1E32B /* Result.framework */; };
-		1EA603A61AF0272E00B1E32B /* Box.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 1EA603A21AF0272600B1E32B /* Box.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		1EA603A71AF0272E00B1E32B /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 1EA603A31AF0272600B1E32B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1EA603A91AF0298C00B1E32B /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA603A81AF0298C00B1E32B /* Optional.swift */; };
 		1EE819001B0A40CB00445D9F /* PureHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE818FF1B0A40CB00445D9F /* PureHelpers.swift */; };
 /* End PBXBuildFile section */
@@ -40,8 +38,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				1EA603A61AF0272E00B1E32B /* Box.framework in Copy Frameworks */,
-				1EA603A71AF0272E00B1E32B /* Result.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -60,8 +56,8 @@
 		1EA603971AEFE8B800B1E32B /* BackwardPipe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackwardPipe.swift; sourceTree = "<group>"; };
 		1EA603991AF018C500B1E32B /* BackwardPipeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackwardPipeTests.swift; sourceTree = "<group>"; };
 		1EA6039B1AF0259100B1E32B /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
-		1EA603A21AF0272600B1E32B /* Box.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Box.framework; path = Carthage/Build/iOS/Box.framework; sourceTree = "<group>"; };
-		1EA603A31AF0272600B1E32B /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/iOS/Result.framework; sourceTree = "<group>"; };
+		1EA603A21AF0272600B1E32B /* Box.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Box.framework; sourceTree = BUILD_PRODUCTS_DIR; };
+		1EA603A31AF0272600B1E32B /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILD_PRODUCTS_DIR; };
 		1EA603A81AF0298C00B1E32B /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		1EE818FF1B0A40CB00445D9F /* PureHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PureHelpers.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -374,10 +370,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Pipes/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -396,10 +389,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Pipes/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -415,7 +405,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -433,7 +422,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = PipesTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
This change enables Pipes to be used as a subproject or workspace project. 
